### PR TITLE
fix: update validations to properly skip if null provided

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -9,4 +9,3 @@ The text below should describe exactly what resources are provisioned / configur
 An end-to-end basic example that will provision the following:
 - A new Trusted Profile
 - A valid Access Policy for the profile
-- A valid Claim Rule for the Policy

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,14 +9,4 @@ module "trusted_profile" {
     roles              = ["Viewer"]
     account_management = true
   }]
-  trusted_profile_claim_rules = [{
-    type = "Profile-CR"
-    conditions = [{
-      claim    = "Groups"
-      operator = "CONTAINS"
-      value    = "\"Admin\""
-    }]
-    name    = "rule-1"
-    cr_type = "IKS_SA"
-  }]
 }

--- a/main.tf
+++ b/main.tf
@@ -117,13 +117,13 @@ resource "ibm_iam_trusted_profile_policy" "policy" {
 
 locals {
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_type = [
+  validate_claim_type = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules : (
       contains(["Profile-SAML", "Profile-CR"], claim.type) ? true : tobool("Value for `var.trusted_profile_claim_rules[${i}].type must be either `Profile-SAML` or `Profile-CR`.")
     )
   ]
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_condition_operator = [
+  validate_claim_condition_operator = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules : [
       for j, condition in claim.conditions : (
         contains(["EQUALS", "NOT_EQUALS", "EQUALS_IGNORE_CASE", "NOT_EQUALS_IGNORE_CASE", "CONTAINS", "IN"], condition.operator) ?
@@ -132,34 +132,34 @@ locals {
     ]
   ]
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_cr_type = [
+  validate_claim_cr_type = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules :
     lookup(claim, "cr_type", null) == null ? true : (
       claim.type == "Profile-CR" ? true : tobool("Value for `var.trusted_profile_claim_rules[${i}].cr_type` should only be provided when `var.trusted_profile_claim_rules[${i}].type` is `Profile-CR`.")
     )
   ]
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_cr_type_matches = [
+  validate_claim_cr_type_matches = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules :
     lookup(claim, "cr_type", null) == null ? true : (
       contains(["VSI", "IKS_SA", "ROKS_SA"], claim.cr_type) ? true : tobool("Value for `var.trusted_profile_claim_rules[${i}].cr_type` must be one of the following: `VSI`, `IKS_SA`, `ROKS_SA`.")
     )
   ]
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_expiration = [
+  validate_claim_expiration = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules :
     lookup(claim, "expiration", null) == null ? true : (
       claim.type == "Profile-SAML" ? true : tobool("Value for `var.trusted_profile_claim_rules[${i}].expiration` should only be provided when `var.trusted_profile_claim_rules[${i}].type` is `Profile-SAML`.")
     )
   ]
   # tflint-ignore: terraform_unused_declarations
-  validate_claim_realm_name = [
+  validate_claim_realm_name = var.trusted_profile_claim_rules == null ? [] : [
     for i, claim in var.trusted_profile_claim_rules :
     lookup(claim, "realm_name", null) == null ? true : (
       claim.type == "Profile-SAML" ? true : tobool("Value for `var.trusted_profile_claim_rules[${i}].realm_name` should only be provided when `var.trusted_profile_claim_rules[${i}].type` is `Profile-SAML`.")
     )
   ]
-  claim_map = {
+  claim_map = var.trusted_profile_claim_rules == null ? {} : {
     for i, obj in var.trusted_profile_claim_rules :
     "${var.trusted_profile_name}-${i}" => {
       conditions = {


### PR DESCRIPTION
### Description
Claim rules map is optional but all of the validations and the map translation didn't properly skip the check if the value isn't provided, updated the validations to now skip and removed passing a value for the claim rule in the basic example to catch this issue in the future

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Bugfix for validation of `trusted_profile_claim_rules` variable

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
