### PR TITLE
fix: add uniqueness to the template test

### DIFF
--- a/examples/tp-template/main.tf
+++ b/examples/tp-template/main.tf
@@ -38,7 +38,7 @@ module "trusted_profile_template" {
     {
       name        = "${var.prefix}-cos-reader-access"
       description = "COS reader access"
-      roles       = ["Reader"]
+      roles       = var.service_roles
       service     = "service"
     }
   ]

--- a/examples/tp-template/variables.tf
+++ b/examples/tp-template/variables.tf
@@ -20,3 +20,9 @@ variable "resource_group" {
   description = "An existing resource group name to use for this example, if unset a new resource group will be created"
   default     = null
 }
+
+variable "service_roles" {
+  type        = list(string)
+  description = "A list of roles to apply to the trusted profile template for the sample Object Storage instance created by the example"
+  default     = ["Reader"]
+}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -59,6 +59,10 @@ func TestRunUpgradeExample(t *testing.T) {
 func TestRunTemplateExample(t *testing.T) {
 
 	options := setupTemplateOptions(t, "tp-template", templateExampleDir)
+	options.TerraformVars = map[string]interface{}{
+		"prefix":        options.Prefix,
+		"service_roles": []string{"Reader", "Content Reader"},
+	}
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")


### PR DESCRIPTION
### Description
Add the ability to provide the roles applied to the trusted profile template in order for them to be unique so that the tests do not fail for identical templates in the same account
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
