### PR TITLE
feat: added the ability to specify account IDs

### DIFF
--- a/examples/tp-template/main.tf
+++ b/examples/tp-template/main.tf
@@ -39,8 +39,17 @@ module "trusted_profile_template" {
       name        = "${var.prefix}-cos-reader-access"
       description = "COS reader access"
       roles       = ["Reader"]
-      service     = "service"
+      attributes = [{
+        key      = "serviceName"
+        value    = "cloud-object-storage"
+        operator = "stringEquals"
+        },
+        {
+          key      = "serviceInstance"
+          value    = module.cos.cos_instance_guid
+          operator = "stringEquals"
+      }]
     }
   ]
-  onboard_all_account_groups = false # Set this to true to add the template to all account groups. Support for selecting specific groups is coming in https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile/issues/163
+  account_group_ids_to_assign = ["all"]
 }

--- a/examples/tp-template/main.tf
+++ b/examples/tp-template/main.tf
@@ -51,5 +51,5 @@ module "trusted_profile_template" {
       }]
     }
   ]
-  account_group_ids_to_assign = ["all"]
+  account_group_ids_to_assign = var.account_group_ids_to_assign
 }

--- a/examples/tp-template/main.tf
+++ b/examples/tp-template/main.tf
@@ -51,5 +51,5 @@ module "trusted_profile_template" {
       }]
     }
   ]
-  account_group_ids_to_assign = [] # add list of enterprise account group IDs to assign the template to. Or use the syntax ["all"] to assign to all
+  account_group_ids_to_assign = ["all"]
 }

--- a/examples/tp-template/main.tf
+++ b/examples/tp-template/main.tf
@@ -51,5 +51,5 @@ module "trusted_profile_template" {
       }]
     }
   ]
-  account_group_ids_to_assign = ["all"]
+  account_group_ids_to_assign = [] # add list of enterprise account group IDs to assign the template to. Or use the syntax ["all"] to assign to all
 }

--- a/examples/tp-template/variables.tf
+++ b/examples/tp-template/variables.tf
@@ -20,3 +20,10 @@ variable "resource_group" {
   description = "An existing resource group name to use for this example, if unset a new resource group will be created"
   default     = null
 }
+
+variable "account_group_ids_to_assign" {
+  type        = list(string)
+  default     = ["all"]
+  description = "A list of account group IDs to assign the template to. Support passing the string 'all' in the list to assign to all account groups."
+  nullable    = false
+}

--- a/modules/trusted-profile-template/README.md
+++ b/modules/trusted-profile-template/README.md
@@ -75,6 +75,7 @@ No modules.
 | [ibm_iam_policy_template.profile_template_policies](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_policy_template) | resource |
 | [ibm_iam_trusted_profile_template.trusted_profile_template_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_trusted_profile_template) | resource |
 | [ibm_iam_trusted_profile_template_assignment.account_settings_template_assignment_instance](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_trusted_profile_template_assignment) | resource |
+| [terraform_data.iam_policy_template_replacement](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [ibm_enterprise_account_groups.all_groups](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/enterprise_account_groups) | data source |
 | [ibm_enterprise_accounts.all_accounts](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/enterprise_accounts) | data source |
 

--- a/modules/trusted-profile-template/README.md
+++ b/modules/trusted-profile-template/README.md
@@ -21,13 +21,26 @@ module "trusted_profile_template" {
       name        = "identity-access"
       description = "Policy template for identity services"
       roles       = ["Viewer", "Reader"]
-      service     = "service"
+      attributes = [{
+        key      = "serviceName"
+        value    = "cloud-object-storage"
+        operator = "stringEquals"
+        },
+        {
+          key      = "serviceInstance"
+          value    = "xxxXXXxxxXXXxxxXXX"
+          operator = "stringEquals"
+      }]
     },
     {
       name        = "platform-access"
       description = "Policy template for platform services"
       roles       = ["Viewer", "Service Configuration Reader"]
-      service     = "platform_service"
+      attributes  = [{
+        key      = "serviceType"
+        value    = "platform_service"
+        operator = "stringEquals"
+      }]
     }
   ]
 }
@@ -69,9 +82,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_group_ids_to_assign"></a> [account\_group\_ids\_to\_assign](#input\_account\_group\_ids\_to\_assign) | A list of account group IDs to assign the template to. Support passing the string 'all' in the list to assign to all account groups. | `list(string)` | <pre>[<br/>  "all"<br/>]</pre> | no |
 | <a name="input_identity_crn"></a> [identity\_crn](#input\_identity\_crn) | CRN of the identity | `string` | n/a | yes |
-| <a name="input_onboard_all_account_groups"></a> [onboard\_all\_account\_groups](#input\_onboard\_all\_account\_groups) | Whether to onboard all account groups to the template. | `bool` | `true` | no |
-| <a name="input_policy_templates"></a> [policy\_templates](#input\_policy\_templates) | List of IAM policy templates to create | <pre>list(object({<br/>    name        = string<br/>    description = string<br/>    roles       = list(string)<br/>    service     = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_policy_templates"></a> [policy\_templates](#input\_policy\_templates) | List of IAM policy templates to create | <pre>list(object({<br/>    name        = string<br/>    description = string<br/>    roles       = list(string)<br/>    attributes = list(object({<br/>      key      = string<br/>      value    = string<br/>      operator = string<br/>    }))<br/>  }))</pre> | n/a | yes |
 | <a name="input_profile_description"></a> [profile\_description](#input\_profile\_description) | Description of the trusted profile inside the template | `string` | `null` | no |
 | <a name="input_profile_name"></a> [profile\_name](#input\_profile\_name) | Name of the trusted profile inside the template | `string` | n/a | yes |
 | <a name="input_template_description"></a> [template\_description](#input\_template\_description) | Description of the trusted profile template | `string` | `null` | no |

--- a/modules/trusted-profile-template/main.tf
+++ b/modules/trusted-profile-template/main.tf
@@ -23,6 +23,14 @@ resource "ibm_iam_policy_template" "profile_template_policies" {
     # TODO support tags (https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile/issues/164)
     roles = each.value.roles
   }
+  # Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6213
+  lifecycle {
+    replace_triggered_by = [terraform_data.iam_policy_template_replacement]
+  }
+}
+
+resource "terraform_data" "iam_policy_template_replacement" {
+  input = var.policy_templates
 }
 
 resource "ibm_iam_trusted_profile_template" "trusted_profile_template_instance" {
@@ -51,6 +59,11 @@ resource "ibm_iam_trusted_profile_template" "trusted_profile_template_instance" 
   }
 
   committed = true
+
+  # Temp workaround for https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6214
+  lifecycle {
+    replace_triggered_by = [terraform_data.iam_policy_template_replacement]
+  }
 }
 
 data "ibm_enterprise_accounts" "all_accounts" {}

--- a/modules/trusted-profile-template/main.tf
+++ b/modules/trusted-profile-template/main.tf
@@ -3,7 +3,6 @@ resource "ibm_iam_policy_template" "profile_template_policies" {
     for pt in var.policy_templates :
     pt.name => pt
   }
-
   name      = each.value.name
   committed = true
 
@@ -12,13 +11,16 @@ resource "ibm_iam_policy_template" "profile_template_policies" {
     description = each.value.description
 
     resource {
-      attributes {
-        key      = "serviceType"
-        value    = each.value.service
-        operator = "stringEquals"
+      dynamic "attributes" {
+        for_each = each.value.attributes
+        content {
+          key      = attributes.value.key
+          value    = attributes.value.value
+          operator = attributes.value.operator
+        }
       }
     }
-
+    # TODO support tags (https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile/issues/164)
     roles = each.value.roles
   }
 }
@@ -65,14 +67,32 @@ locals {
     }
   ]
 
-  combined_targets = {
+  compared_list = flatten(
+    [
+      for group in local.group_targets :
+      [
+        for provided_group in var.account_group_ids_to_assign :
+        provided_group if group.id == provided_group
+      ]
+    ]
+  )
+
+  all_groups = length(var.account_group_ids_to_assign) > 0 ? var.account_group_ids_to_assign[0] == "all" ? true : false : false
+  # tflint-ignore: terraform_unused_declarations
+  validate_group_ids = !local.all_groups ? length(local.compared_list) != length(var.account_group_ids_to_assign) ? tobool("Could not find all of the groups listed in the 'account_group_ids_to_assign' value. Please verify all values are correct") : true : true
+
+  combined_targets = local.all_groups ? {
     for target in local.group_targets :
     "${target.type}-${target.id}" => target
+    } : {
+    for target in local.group_targets :
+    "${target.type}-${target.id}" => target if contains(var.account_group_ids_to_assign, target.id)
   }
+
 }
 
 resource "ibm_iam_trusted_profile_template_assignment" "account_settings_template_assignment_instance" {
-  for_each = var.onboard_all_account_groups ? local.combined_targets : {}
+  for_each = local.combined_targets
 
   template_id      = split("/", ibm_iam_trusted_profile_template.trusted_profile_template_instance.id)[0]
   template_version = ibm_iam_trusted_profile_template.trusted_profile_template_instance.version

--- a/modules/trusted-profile-template/variables.tf
+++ b/modules/trusted-profile-template/variables.tf
@@ -16,16 +16,24 @@ variable "policy_templates" {
     name        = string
     description = string
     roles       = list(string)
-    service     = string
+    attributes = list(object({
+      key      = string
+      value    = string
+      operator = string
+    }))
   }))
 }
 
-# TODO: Add support to select which account groups to add trusted profile template to:
-#       https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile/issues/163
-variable "onboard_all_account_groups" {
-  type        = bool
-  default     = true
-  description = "Whether to onboard all account groups to the template."
+variable "account_group_ids_to_assign" {
+  type        = list(string)
+  default     = ["all"]
+  description = "A list of account group IDs to assign the template to. Support passing the string 'all' in the list to assign to all account groups."
+  nullable    = false
+
+  validation {
+    condition     = contains(var.account_group_ids_to_assign, "all") ? length(var.account_group_ids_to_assign) == 1 : true
+    error_message = "When specifying 'all' in the list, you cannot add any other values to the list"
+  }
 }
 
 variable "profile_name" {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -26,6 +26,12 @@ func setupTemplateOptions(t *testing.T, prefix string, dir string) *testhelper.T
 		Testing:      t,
 		TerraformDir: dir,
 		Prefix:       prefix,
+		// Workaround for provider bug https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6216
+		IgnoreUpdates: testhelper.Exemptions{
+			List: []string{
+				"module.trusted_profile_template.ibm_iam_trusted_profile_template_assignment",
+			},
+		},
 	})
 	terraformVars := map[string]interface{}{
 		"prefix": options.Prefix,

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -29,7 +29,7 @@ func setupTemplateOptions(t *testing.T, prefix string, dir string) *testhelper.T
 		// Workaround for provider bug https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6216
 		IgnoreUpdates: testhelper.Exemptions{
 			List: []string{
-				"module.trusted_profile_template.ibm_iam_trusted_profile_template_assignment",
+				"module.trusted_profile_template.ibm_iam_trusted_profile_template_assignment.account_settings_template_assignment_instance",
 			},
 		},
 	})

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -26,15 +26,11 @@ func setupTemplateOptions(t *testing.T, prefix string, dir string) *testhelper.T
 		Testing:      t,
 		TerraformDir: dir,
 		Prefix:       prefix,
-		// Workaround for provider bug https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6216
-		IgnoreUpdates: testhelper.Exemptions{
-			List: []string{
-				"module.trusted_profile_template.ibm_iam_trusted_profile_template_assignment.account_settings_template_assignment_instance",
-			},
-		},
 	})
 	terraformVars := map[string]interface{}{
 		"prefix": options.Prefix,
+		// Workaround for provider bug https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6216
+		"account_group_ids_to_assign": []string{},
 	}
 	options.TerraformVars = terraformVars
 	return options


### PR DESCRIPTION
### Description

- Changed the `policy_templates` schema to allow user to choose exact attributes
- Removed the boolean `onboard_all_account_groups` and replaced it with `account_group_ids_to_assign` which allows consumers to pass a list of account IDs (or pass "all" for all) (https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile/issues/163)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
